### PR TITLE
Updated Safari version for flow-root

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -480,10 +480,10 @@
                 "version_added": "43"
               },
               "safari": {
-                "version_added": false
+                "version_added": "13"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "13"
               },
               "samsunginternet_android": {
                 "version_added": "7.0"


### PR DESCRIPTION
Per issue 6148 https://github.com/mdn/browser-compat-data/issues/6148#issuecomment-628584863
Safari 13 and iOS Safari now support flow-root as of versions 13+

* Only updated from False (no support) to Safari version number 13
* Thank you @ddbeck for all other notes specific to Safari release changes 
